### PR TITLE
docs: fix broken SearchCriteria reference link

### DIFF
--- a/docs/how-to/FILTER-SEARCH-RESULTS.md
+++ b/docs/how-to/FILTER-SEARCH-RESULTS.md
@@ -225,5 +225,5 @@ for group in &groups {
 
 - [How to Compare Animals](COMPARE-ANIMALS.md) -- compare filtered candidates
 - [How to Export JSON](EXPORT-JSON.md) -- export filtered results
-- [SearchCriteria Reference](../reference/SEARCH-CRITERIA.md)
+- [SearchCriteria Reference](../reference/LIBRARY-API.md#searchcriteria)
 - [EBV Trait Glossary](../MCP.md#ebv-trait-glossary)


### PR DESCRIPTION
## Summary

Fixes a broken documentation link in the "How to Filter Search Results" guide.

## Changes

- Updated reference to `SearchCriteria` to point to the correct location in `LIBRARY-API.md#searchcriteria` instead of non-existent `SEARCH-CRITERIA.md`

## Context

The `FILTER-SEARCH-RESULTS.md` file contained a broken link in the "See Also" section. The `SearchCriteria` documentation exists in `docs/reference/LIBRARY-API.md` under its own section, but the link was pointing to a non-existent standalone file.

## Testing

- [x] Verified the target file and anchor exist
- [x] Confirmed no other references to `SEARCH-CRITERIA.md` exist in the documentation
- [x] All other relative links in the docs directory verified

## Documentation Quality

This change improves documentation accuracy and user experience by ensuring all internal links are valid and point to the correct resources.


> AI generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22113615142)

<!-- gh-aw-workflow-id: update-docs -->