### PR TITLE
docs: add TraitDefinition and ebv_glossary API reference

### DIFF
--- a/docs/reference/LIBRARY-API.md
+++ b/docs/reference/LIBRARY-API.md
@@ -635,6 +635,16 @@ Pure computation functions for breeding analytics with no external dependencies.
 | `score` | `f64` | Weighted composite score |
 | `trait_scores` | `HashMap<String, f64>` | Per-trait weighted scores |
 
+**`TraitDefinition`** — EBV trait metadata with interpretation and selection direction.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `abbreviation` | `&'static str` | Trait abbreviation (e.g., `"BWT"`) |
+| `name` | `&'static str` | Full trait name (e.g., `"Birth Weight"`) |
+| `unit` | `&'static str` | Unit of measurement (e.g., `"lbs"`) |
+| `description` | `&'static str` | What the trait measures |
+| `selection_direction` | `&'static str` | Whether higher or lower is better |
+
 #### Functions
 
 **`calculate_coi(sire_lineage: &Lineage, dam_lineage: &Lineage) -> CoiResult`**
@@ -734,6 +744,25 @@ for ancestor in shared {
 # Ok(())
 # }
 ```
+
+**`ebv_glossary() -> Vec<TraitDefinition>`**
+
+Returns complete glossary of all 13 NSIP EBV traits with metadata for each trait.
+
+```rust
+use nsip::mcp::analytics::ebv_glossary;
+
+for trait_def in ebv_glossary() {
+    println!("{} ({}): {} [{}]",
+        trait_def.abbreviation,
+        trait_def.name,
+        trait_def.description,
+        trait_def.selection_direction
+    );
+}
+```
+
+See [EBV Trait Glossary](../MCP.md#ebv-trait-glossary) for the complete trait reference table.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds missing public API documentation for `mcp::analytics` module items that were not previously documented in the Library API Reference.

## Changes

Added documentation for two public items from `crates/mcp/analytics.rs`:

### `TraitDefinition` struct
- Documents all five fields with descriptions
- Shows proper Rust type signatures (`&'static str`)
- Provides example usage context

### `ebv_glossary()` function  
- Documents the function signature and return type
- Includes practical code example showing iteration over results
- Cross-references the complete trait table in `MCP.md#ebv-trait-glossary`

## Documentation Quality

- **Consistency**: Follows existing patterns in `LIBRARY-API.md` (field tables, code examples, cross-references)
- **Completeness**: All public API items in `mcp::analytics` are now documented
- **Accuracy**: Documentation verified against source code in `crates/mcp/analytics.rs:266-281`
- **Discoverability**: Cross-links to related MCP.md documentation

## Testing

- [x] All public items from `mcp::analytics` verified as documented
- [x] Markdown syntax validated
- [x] Cross-reference anchors verified (`#ebv-trait-glossary` exists in MCP.md)
- [x] Code examples follow existing doc test patterns

## Related

Complements recent PR #79 which added comprehensive MCP module documentation.

---

**Documentation gap identified**: These public exports were accessible via `use nsip::mcp::analytics::{TraitDefinition, ebv_glossary};` but were undocumented in the reference manual.


> AI generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22167751177)

<!-- gh-aw-workflow-id: update-docs -->