### PR TITLE
docs: fix NSIP_AUTH_ALLOWED_USERS gap and stale OTLP env var reference

### DIFF
--- a/crates/main.rs
+++ b/crates/main.rs
@@ -220,10 +220,10 @@ fn render_man_page(
 
 /// Initialise the tracing subscriber.
 ///
-/// When compiled with the `telemetry` feature and `NSIP_OTLP_ENDPOINT` is set,
-/// the subscriber includes an `OpenTelemetry` layer that attaches W3C trace
-/// context (`trace_id`, `span_id`) to every JSON log line. Otherwise a plain
-/// text subscriber writing to stderr is used.
+/// When compiled with the `telemetry` feature, the subscriber includes an
+/// `OpenTelemetry` layer that attaches W3C trace context (`trace_id`,
+/// `span_id`) to every JSON log line. Otherwise a plain text subscriber
+/// writing to stderr is used.
 fn init_tracing() {
     init_tracing_inner();
 }

--- a/docs/reference/MCP-SERVER-CONFIGURATION.md
+++ b/docs/reference/MCP-SERVER-CONFIGURATION.md
@@ -72,7 +72,7 @@ Authentication is only meaningful over HTTP. When `--auth` is set, the server re
 
 ### OAuth Environment Variables
 
-The first four variables are required when `--auth` is set. The remaining two are optional with sensible defaults:
+The first four variables are required when `--auth` is set. The remaining three are optional with sensible defaults:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -82,6 +82,7 @@ The first four variables are required when `--auth` is set. The remaining two ar
 | `NSIP_AUTH_BASE_URL` | Yes | — | External base URL for redirect URIs (e.g. `http://localhost:8080`) |
 | `NSIP_AUTH_ISSUER` | No | value of `NSIP_AUTH_BASE_URL` | JWT `iss` claim value. Override when the public-facing issuer URL differs from the base URL. |
 | `NSIP_AUTH_TOKEN_TTL` | No | `3600` | JWT token time-to-live in seconds. |
+| `NSIP_AUTH_ALLOWED_USERS` | No | *(none — all users allowed)* | Comma-separated allowlist of GitHub usernames. When set, only listed users may authenticate. |
 
 ### OAuth Endpoints
 


### PR DESCRIPTION
## Summary

Two documentation accuracy issues found during a nightly documentation sweep.

### 1. Missing `NSIP_AUTH_ALLOWED_USERS` in reference doc

**File:** `docs/reference/MCP-SERVER-CONFIGURATION.md`

The OAuth environment variables table listed only six variables (4 required + 2 optional: `NSIP_AUTH_ISSUER` and `NSIP_AUTH_TOKEN_TTL`). The third optional variable, `NSIP_AUTH_ALLOWED_USERS`, was implemented in the code (`crates/mcp/oauth/config.rs`) and correctly documented in the how-to guide (`docs/how-to/OAUTH-AUTHENTICATION.md`) and the explanation doc (`docs/explanation/MCP-SECURITY.md`), but was absent from the authoritative reference.

**Fix:** Add `NSIP_AUTH_ALLOWED_USERS` row to the table and update the introductory sentence from "remaining **two**" to "remaining **three** are optional".

### 2. Stale `NSIP_OTLP_ENDPOINT` reference in code doc comment

**File:** `crates/main.rs`

The `init_tracing()` function had a doc comment saying:
> "When compiled with the `telemetry` feature **and `NSIP_OTLP_ENDPOINT` is set**…"

The `NSIP_OTLP_ENDPOINT` environment variable does not exist in the codebase. The telemetry JSON log format is activated solely by the `--features telemetry` compile-time flag, as the implementation confirms (`init_tracing_inner` is `#[cfg(feature = "telemetry")]` with no env-var check). The mention of `NSIP_OTLP_ENDPOINT` was a stale residue that could mislead contributors and users expecting to toggle telemetry at runtime.

**Fix:** Remove the `NSIP_OTLP_ENDPOINT` reference from the doc comment.

---

## Files Changed

| File | Change |
|------|--------|
| `docs/reference/MCP-SERVER-CONFIGURATION.md` | Add `NSIP_AUTH_ALLOWED_USERS` row; fix "two" → "three" |
| `crates/main.rs` | Remove stale `NSIP_OTLP_ENDPOINT` from doc comment |

## Testing

Documentation-only changes (plus a single comment fix in source). No logic changed. Existing tests continue to pass unmodified.




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22865961340) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22865961340, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22865961340 -->

<!-- gh-aw-workflow-id: update-docs -->