### PR TITLE
docs: fix NSIP_AUTH_ISSUER default value and add optional OAuth vars to CONFIGURATION.md

### DIFF
--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -128,6 +128,14 @@ Required when `--auth` is set:
 | `NSIP_AUTH_SECRET` | HMAC-SHA256 secret for JWT signing |
 | `NSIP_AUTH_BASE_URL` | External base URL (e.g. `http://localhost:8080`) |
 
+Optional:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NSIP_AUTH_ISSUER` | `https://localhost` | JWT `iss` claim value |
+| `NSIP_AUTH_TOKEN_TTL` | `3600` | JWT token time-to-live in seconds |
+| `NSIP_AUTH_ALLOWED_USERS` | *(none)* | Comma-separated allowlist of GitHub usernames |
+
 ### Telemetry
 
 When compiled with `--features telemetry`, the server logs in JSON format with W3C trace context (`trace_id`, `span_id`). Default build uses plain text tracing.

--- a/docs/reference/MCP-SERVER-CONFIGURATION.md
+++ b/docs/reference/MCP-SERVER-CONFIGURATION.md
@@ -80,7 +80,7 @@ The first four variables are required when `--auth` is set. The remaining three 
 | `NSIP_GITHUB_CLIENT_SECRET` | Yes | — | GitHub OAuth app client secret |
 | `NSIP_AUTH_SECRET` | Yes | — | HMAC-SHA256 secret for JWT signing (minimum 32 characters recommended) |
 | `NSIP_AUTH_BASE_URL` | Yes | — | External base URL for redirect URIs (e.g. `http://localhost:8080`) |
-| `NSIP_AUTH_ISSUER` | No | value of `NSIP_AUTH_BASE_URL` | JWT `iss` claim value. Override when the public-facing issuer URL differs from the base URL. |
+| `NSIP_AUTH_ISSUER` | No | `https://localhost` | JWT `iss` claim value. Override when the public-facing issuer URL differs from the base URL. |
 | `NSIP_AUTH_TOKEN_TTL` | No | `3600` | JWT token time-to-live in seconds. |
 | `NSIP_AUTH_ALLOWED_USERS` | No | *(none — all users allowed)* | Comma-separated allowlist of GitHub usernames. When set, only listed users may authenticate. |
 


### PR DESCRIPTION
## What

Two documentation fixes to OAuth environment variable references:

### 1. Incorrect default for `NSIP_AUTH_ISSUER` in `MCP-SERVER-CONFIGURATION.md`

The default value was documented as `value of NSIP_AUTH_BASE_URL` but the actual code default is the string literal `(localhost/redacted)`:

```rust
// crates/mcp/oauth/config.rs
const DEFAULT_ISSUER: &str = "(localhost/redacted)";
```

This was already documented correctly in two other files:
- `docs/how-to/OAUTH-AUTHENTICATION.md` — shows `(localhost/redacted)` ✅
- `docs/explanation/MCP-SECURITY.md` — shows `default (localhost/redacted)` ✅

**Fix:** Updated `MCP-SERVER-CONFIGURATION.md` to match the code and the other docs.

### 2. Missing optional OAuth variables in `CONFIGURATION.md`

`docs/reference/CONFIGURATION.md` listed only the four _required_ OAuth variables and omitted the three optional ones (`NSIP_AUTH_ISSUER`, `NSIP_AUTH_TOKEN_TTL`, `NSIP_AUTH_ALLOWED_USERS`), leaving readers without a complete picture in that file.

**Fix:** Added an "Optional" table section below the existing required-variables table.

## Files Changed

| File | Change |
|------|--------|
| `docs/reference/MCP-SERVER-CONFIGURATION.md` | Fix `NSIP_AUTH_ISSUER` default from `value of NSIP_AUTH_BASE_URL` → `` `(localhost/redacted)` `` |
| `docs/reference/CONFIGURATION.md` | Add optional OAuth variables table |

## Testing

No code changes — documentation only. Values verified against `crates/mcp/oauth/config.rs`.




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22866438537) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22866438537, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22866438537 -->

<!-- gh-aw-workflow-id: update-docs -->