### PR TITLE
docs: fix incorrect method names in LIBRARY-API.md analytics examples

### DIFF
--- a/docs/reference/LIBRARY-API.md
+++ b/docs/reference/LIBRARY-API.md
@@ -677,16 +677,20 @@ Score formula: `Σ (trait_value × weight × accuracy/100)` for each trait.
 
 ```rust
 use std::collections::HashMap;
-use nsip::{NsipClient, mcp::analytics::rank_animals};
+use nsip::{AnimalDetails, NsipClient, SearchCriteria, mcp::analytics::rank_animals};
 
 # async fn example() -> nsip::Result<()> {
 let client = NsipClient::new();
-let search = client.search(
-    nsip::SearchCriteria::new()
-        .with_breed_id(486)
-        .with_gender("Male")
-        .with_status("CURRENT")
-).await?;
+let criteria = SearchCriteria::new()
+    .with_breed_id(486)
+    .with_gender("Male")
+    .with_status("CURRENT");
+let search = client.search_animals(0, 50, Some(486), None, None, Some(&criteria)).await?;
+
+let animals: Vec<AnimalDetails> = search.results
+    .iter()
+    .filter_map(|r| AnimalDetails::from_api_response(r).ok())
+    .collect();
 
 let weights = HashMap::from([
     ("BWT".to_string(), -1.0),
@@ -694,7 +698,7 @@ let weights = HashMap::from([
     ("YWT".to_string(), 1.5),
 ]);
 
-let ranked = rank_animals(&search.animals, &weights);
+let ranked = rank_animals(&animals, &weights);
 for animal in ranked.iter().take(5) {
     println!("{}: {:.2}", animal.lpn_id, animal.score);
 }
@@ -713,8 +717,8 @@ use nsip::{NsipClient, mcp::analytics::trait_complementarity};
 
 # async fn example() -> nsip::Result<()> {
 let client = NsipClient::new();
-let sire = client.details("430735-0032").await?;
-let dam = client.details("430735-0089").await?;
+let sire = client.animal_details("430735-0032").await?;
+let dam = client.animal_details("430735-0089").await?;
 
 let midparent_ebvs = trait_complementarity(&sire, &dam);
 for (trait_name, value) in midparent_ebvs {


### PR DESCRIPTION
## Summary

Two code examples in `docs/reference/LIBRARY-API.md` (analytics submodule section) referenced non-existent methods on `NsipClient`, making them copy-paste-incorrect for users.

### Bugs Fixed

**1. `rank_animals` example — wrong search method and wrong result field**

Before:
```rust
let search = client.search(
    nsip::SearchCriteria::new()
        .with_breed_id(486)
        ...
).await?;

let ranked = rank_animals(&search.animals, &weights);
```

After:
```rust
let criteria = SearchCriteria::new()
    .with_breed_id(486)
    ...;
let search = client.search_animals(0, 50, Some(486), None, None, Some(&criteria)).await?;

let animals: Vec(AnimalDetails) = search.results
    .iter()
    .filter_map(|r| AnimalDetails::from_api_response(r).ok())
    .collect();

let ranked = rank_animals(&animals, &weights);
```

- `client.search()` does not exist → correct method is `client.search_animals(page, page_size, breed_id, sorted_trait, reverse, criteria)`
- `SearchResults` has a `results: Vec(serde_json::Value)` field, **not** `animals` (that field lives on `Progeny`)
- `rank_animals` takes `&[AnimalDetails]`, so the raw JSON results must be parsed via `AnimalDetails::from_api_response` — matching the pattern used internally in `crates/mcp/tools.rs`

**2. `trait_complementarity` example — wrong details method**

Before:
```rust
let sire = client.details("430735-0032").await?;
let dam  = client.details("430735-0089").await?;
```

After:
```rust
let sire = client.animal_details("430735-0032").await?;
let dam  = client.animal_details("430735-0089").await?;
```

`client.details()` does not exist → correct method is `client.animal_details(search_string)`.

### Impact

Documentation-only change. No code changes. Fixes misleading examples that would not compile if copied directly.

### Verification

- Confirmed `NsipClient::search_animals` signature: `(page, page_size, breed_id, sorted_trait, reverse, criteria) -> Result(SearchResults)`
- Confirmed `SearchResults::results: Vec(serde_json::Value)`  
- Confirmed `AnimalDetails::from_api_response` is `pub`
- Confirmed `NsipClient::animal_details` is the correct method name
- Cross-referenced with `crates/mcp/tools.rs` `rank` handler for the correct usage pattern




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22867667151) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22867667151, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22867667151 -->

<!-- gh-aw-workflow-id: update-docs -->