### PR TITLE
docs: fix `serve_stdio` signature and add missing `serve_http` / `with_tool_sets` to LIBRARY-API.md

### DIFF
--- a/docs/reference/LIBRARY-API.md
+++ b/docs/reference/LIBRARY-API.md
@@ -577,7 +577,7 @@ let server = NsipServer::new();
 
 #### `NsipServer::new() -> Self`
 
-Create a new MCP server instance with default NSIP API client.
+Create a new MCP server instance with all 13 tools enabled.
 
 ```rust
 use nsip::mcp::NsipServer;
@@ -585,18 +585,56 @@ use nsip::mcp::NsipServer;
 let server = NsipServer::new();
 ```
 
-#### `serve_stdio() -> Result<()>`
+#### `NsipServer::with_tool_sets(sets: EnabledToolSets) -> Self`
+
+Create an MCP server with a restricted set of tools. Use this when embedding the server
+programmatically and you want finer control over which tool categories are exposed.
+
+```rust
+use nsip::mcp::{NsipServer, tool_sets::EnabledToolSets};
+
+// Expose only search and breed tools
+let sets = EnabledToolSets::from_csv("search,breed");
+let server = NsipServer::with_tool_sets(sets);
+```
+
+#### `serve_stdio(sets: EnabledToolSets) -> Result<()>`
 
 Start the MCP server on stdio transport (used by Claude Desktop, Claude Code, Cursor, etc.).
 
+Pass `EnabledToolSets::all()` to expose all 13 tools, or build a filtered set with
+[`EnabledToolSets::from_csv`] to restrict which tool categories are active.
+
 ```rust
-use nsip::mcp::serve_stdio;
+use nsip::mcp::{serve_stdio, tool_sets::EnabledToolSets};
 
 #[tokio::main]
 async fn main() -> nsip::Result<()> {
-    serve_stdio().await
+    serve_stdio(EnabledToolSets::all()).await
 }
 ```
+
+#### `serve_http(host: &str, port: u16, sets: EnabledToolSets, oauth_state: Option<OAuthState>) -> Result<()>`
+
+Start the MCP server on HTTP transport with optional OAuth 2.1 authentication.
+
+- **`host`** — bind address (e.g., `"127.0.0.1"` or `"0.0.0.0"`)
+- **`port`** — TCP port to listen on
+- **`sets`** — which tool categories to expose (see [`EnabledToolSets`])
+- **`oauth_state`** — when `Some`, enables GitHub-backed OAuth 2.1 + PAT bearer auth; `None` disables auth
+
+```rust
+use nsip::mcp::{serve_http, tool_sets::EnabledToolSets};
+
+#[tokio::main]
+async fn main() -> nsip::Result<()> {
+    // HTTP server with all tools, no auth
+    serve_http("127.0.0.1", 8080, EnabledToolSets::all(), None).await
+}
+```
+
+**Errors:** Returns `Error::Connection` if the TCP listener cannot bind or the server encounters
+a runtime error.
 
 ---
 


### PR DESCRIPTION
## What changed

`docs/reference/LIBRARY-API.md` contained three gaps in the `mcp` module section:

| Issue | Detail |
|-------|--------|
| **Wrong signature** | `serve_stdio()` was documented as taking no arguments, but the actual Rust signature is `serve_stdio(sets: EnabledToolSets) -> Result<()>` |
| **Bad example** | The inline code example called `serve_stdio().await` — this does not compile against the real API |
| **Missing functions** | `NsipServer::with_tool_sets()` and `serve_http()` were both public API but had no documentation at all |

## Changes

- **Fix `serve_stdio()` signature** — now shows the required `sets: EnabledToolSets` parameter
- **Fix `serve_stdio()` example** — calls `serve_stdio(EnabledToolSets::all()).await`
- **Add `NsipServer::with_tool_sets()`** — documents the programmatic tool-set filtering constructor with an example
- **Add `serve_http()`** — full parameter documentation (`host`, `port`, `sets`, `oauth_state`) with example and error note

## Testing

Documentation-only change. No code was modified. Verified by cross-referencing:
- `crates/mcp/mod.rs` (`serve_stdio`, line 228)
- `crates/mcp/transport.rs` (`serve_http`, line 28)
- `crates/mcp/tools.rs` (`NsipServer::with_tool_sets`, line 242)




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22871809998) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22871809998, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22871809998 -->

<!-- gh-aw-workflow-id: update-docs -->