### PR TITLE
docs: fix stale version and MCP protocol version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nsip = "0.3"
+nsip = "0.4"
 ```
 
 Or use cargo add:
@@ -314,8 +314,8 @@ This template includes production-ready workflows:
 1. Update version in `Cargo.toml`
 2. Create and push a version tag:
    ```bash
-   git tag -a v0.3.0 -m "Release v0.3.0"
-   git push origin v0.3.0
+   git tag -a v0.4.0 -m "Release v0.4.0"
+   git push origin v0.4.0
    ```
 3. Workflows automatically:
    - Generate changelog
@@ -340,8 +340,8 @@ Pull and run the container:
 docker pull ghcr.io/zircote/nsip:latest
 
 # Run specific version
-docker pull ghcr.io/zircote/nsip:v0.1.0
-docker run --rm ghcr.io/zircote/nsip:v0.1.0 --version
+docker pull ghcr.io/zircote/nsip:v0.4.0
+docker run --rm ghcr.io/zircote/nsip:v0.4.0 --version
 ```
 
 ## MSRV Policy

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,7 +35,7 @@ Update version in `Cargo.toml`:
 
 ```toml
 [package]
-version = "0.3.0"  # Update this
+version = "0.4.0"  # Update this
 ```
 
 Run checks locally:

--- a/docs/how-to/USE-MCP-TOOLS.md
+++ b/docs/how-to/USE-MCP-TOOLS.md
@@ -64,7 +64,7 @@ If you prefer not to install the binary:
 Test that the server responds to an MCP initialize request:
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | nsip mcp
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | nsip mcp
 ```
 
 A successful response includes `"result"` with server capabilities.

--- a/docs/tutorials/GETTING-STARTED.md
+++ b/docs/tutorials/GETTING-STARTED.md
@@ -37,7 +37,7 @@ Your `Cargo.toml` should now include:
 
 ```toml
 [dependencies]
-nsip = "0.3"
+nsip = "0.4"
 tokio = { version = "1", features = ["full"] }
 ```
 


### PR DESCRIPTION
## Summary

Daily documentation review found stale version references and a mismatched MCP protocol version across several docs files.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `README.md` | Dependency snippet showed `nsip = "0.3"` (crate is now `0.4.0`) | Updated to `nsip = "0.4"` |
| `README.md` | Docker example used `v0.1.0` tag | Updated to `v0.4.0` |
| `README.md` | "Creating a Release" example used `v0.3.0` tag | Updated to `v0.4.0` |
| `docs/DEPLOYMENT.md` | Cargo.toml example showed `version = "0.3.0"` | Updated to `version = "0.4.0"` |
| `docs/tutorials/GETTING-STARTED.md` | Dependency snippet showed `nsip = "0.3"` | Updated to `nsip = "0.4"` |
| `docs/how-to/USE-MCP-TOOLS.md` | MCP `initialize` example used protocol version `2024-11-05` | Updated to `2025-06-18` (consistent with all other docs and MCP.md) |

## Verification

All other uses of `2025-06-18` in `docs/MCP.md` and `docs/tutorials/MCP-SERVER-SETUP.md` were already correct — only the one file had the old protocol version. The crate version is `0.4.0` as confirmed in `Cargo.toml` and `CHANGELOG.md`.

No code changes; documentation only.




> Generated by [Daily Documentation Review](https://github.com/zircote/nsip/actions/runs/22879780092) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+daily-docs-review%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Daily Documentation Review, engine: copilot, id: 22879780092, workflow_id: daily-docs-review, run: https://github.com/zircote/nsip/actions/runs/22879780092 -->

<!-- gh-aw-workflow-id: daily-docs-review -->