### PR TITLE
docs: fix `serve_stdio` signature and MCP tool names in MCP-SERVER-SETUP tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ nsip mcp
 The library includes MCP (Model Context Protocol) support for integration with AI assistants:
 
 ```rust,ignore
-// Start the MCP server on stdio
-nsip::mcp::serve_stdio().await?;
+use nsip::mcp::{serve_stdio, tool_sets::EnabledToolSets};
+
+// Start the MCP server on stdio (all 13 tools enabled)
+serve_stdio(EnabledToolSets::all()).await?;
 ```
 
 The MCP protocol exposes the following 13 tools when running `nsip mcp`:

--- a/docs/tutorials/MCP-SERVER-SETUP.md
+++ b/docs/tutorials/MCP-SERVER-SETUP.md
@@ -148,7 +148,7 @@ In your AI client, try asking a question that uses the NSIP tools:
 What breed groups are available in the NSIP database?
 ```
 
-The AI assistant should use the `list_breed_groups` tool and return a list of breed groups with their breeds.
+The AI assistant should use the `breed_groups` tool and return a list of breed groups with their breeds.
 
 Try a few more queries:
 
@@ -174,19 +174,19 @@ The NSIP MCP server provides 13 tools:
 
 | Tool | Description |
 |------|-------------|
-| `search_animals` | Search animals with filters (breed, gender, status, date range) |
-| `animal_details` | Get detailed information for a specific animal |
-| `animal_profile` | Get a complete profile (details + lineage + progeny) |
-| `animal_lineage` | Get multi-generational pedigree data |
-| `animal_progeny` | List an animal's offspring |
-| `compare_animals` | Side-by-side trait comparison of multiple animals |
-| `list_breed_groups` | List all breed groups and their breeds |
-| `list_statuses` | List valid animal status values |
-| `trait_ranges` | Get min/max trait values for a breed |
-| `date_last_updated` | Check when the database was last updated |
-| `breed_group_details` | Get details for a specific breed group |
-| `trait_definitions` | Get EBV trait definitions and units |
-| `flock_search` | Search for flocks by criteria |
+| `search` | Search for animals with filters (breed, gender, status, date range, flock) |
+| `details` | Get detailed EBV data, breed, contact info, and status for an animal |
+| `lineage` | Get pedigree / ancestry tree including parents and grandparents |
+| `progeny` | Get paginated list of offspring for an animal |
+| `profile` | Get complete profile (details + lineage + progeny) in one call |
+| `compare` | Compare 2–5 animals side-by-side on their EBV traits |
+| `rank` | Rank animals within a breed by weighted EBV trait scores |
+| `inbreeding_check` | Calculate Wright's coefficient of inbreeding for a sire-dam pairing |
+| `mating_recommendations` | Find optimal mates ranked by trait complementarity and low COI |
+| `flock_summary` | Summarize a flock's animals: count, gender breakdown, and average EBVs |
+| `database_status` | Get last-updated date and available animal statuses |
+| `breed_groups` | List all breed groups and individual breeds |
+| `trait_ranges` | Get min/max EBV trait value ranges for a specific breed |
 
 The server also provides 7 guided prompts that help structure common queries. Ask your AI assistant to list the available prompts for more details.
 


### PR DESCRIPTION
## What & Why

Two documentation accuracy bugs found during a nightly documentation review:

### 1. `README.md` — incorrect `serve_stdio()` call

The MCP Integration code snippet showed the function being called with no arguments:

```rust
nsip::mcp::serve_stdio().await?;
```

The actual signature (introduced / corrected in #165) is:

```rust
pub async fn serve_stdio(sets: tool_sets::EnabledToolSets) -> crate::Result<()>
```

**Fix:** Updated the snippet to show the correct call with an import and `EnabledToolSets::all()`.

---

### 2. `docs/tutorials/MCP-SERVER-SETUP.md` — invented tool names in Steps 4 and 5

Step 4 referred to `list_breed_groups` and Step 5 listed 13 tools that do not exist (`search_animals`, `animal_details`, `animal_profile`, `animal_lineage`, `animal_progeny`, `compare_animals`, `list_breed_groups`, `list_statuses`, `breed_group_details`, `trait_definitions`, `flock_search`). Three real tools were also missing entirely (`rank`, `inbreeding_check`, `mating_recommendations`).

**Fix:** Replaced the fabricated names with the actual 13 tool names registered in `crates/mcp/tool_sets.rs` and described in `docs/MCP.md` and `docs/reference/MCP-TOOLS.md`.

| Before (incorrect) | After (correct) |
|--------------------|-----------------|
| `search_animals` | `search` |
| `animal_details` | `details` |
| `animal_profile` | `profile` |
| `animal_lineage` | `lineage` |
| `animal_progeny` | `progeny` |
| `compare_animals` | `compare` |
| `list_breed_groups` | `breed_groups` |
| `date_last_updated` | `database_status` |
| `flock_search` | `flock_summary` |
| _(missing)_ | `rank` |
| _(missing)_ | `inbreeding_check` |
| _(missing)_ | `mating_recommendations` |
| `list_statuses` _(removed — not a real tool)_ | — |
| `breed_group_details` _(removed)_ | — |
| `trait_definitions` _(removed)_ | — |

## Files Changed

- `README.md` — fix `serve_stdio` call signature
- `docs/tutorials/MCP-SERVER-SETUP.md` — fix tool names in Step 4 and Step 5

## Testing

Documentation-only change. No code paths modified. Verified all 13 tool names against `crates/mcp/tool_sets.rs` `ALL_TOOL_NAMES` constant and `crates/mcp/tools.rs` tool handler implementations.




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22906824768) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22906824768, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22906824768 -->

<!-- gh-aw-workflow-id: update-docs -->