### PR TITLE
docs: fix MCP-TOOLS protocol version and add Diátaxis frontmatter to 26 docs

### DIFF
--- a/docs/explanation/BREED-GROUPS-AND-TRAITS.md
+++ b/docs/explanation/BREED-GROUPS-AND-TRAITS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Breed Groups and Traits
 
 > How NSIP organizes sheep breeds into evaluation groups, and which EBV traits are relevant to each group.

--- a/docs/explanation/DATA-TO-DECISIONS.md
+++ b/docs/explanation/DATA-TO-DECISIONS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # From Data to Decisions
 
 > How NSIP API data connects to real-world sheep breeding decisions, from sire selection through mating plans to flock-level genetic improvement.

--- a/docs/explanation/DYNAMIC-INSTRUCTIONS.md
+++ b/docs/explanation/DYNAMIC-INSTRUCTIONS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Dynamic MCP Server Instructions
 
 > MCP servers describe themselves to clients through an `instructions` field. The NSIP server generates these instructions dynamically so that clients only learn about capabilities they can actually use.

--- a/docs/explanation/EBV-EXPLAINED.md
+++ b/docs/explanation/EBV-EXPLAINED.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Understanding Estimated Breeding Values (EBVs)
 
 > EBVs are the foundation of genetic improvement in sheep. This guide explains what they are, how they work, and why they matter for breeding decisions.

--- a/docs/explanation/GENETIC-EVALUATION.md
+++ b/docs/explanation/GENETIC-EVALUATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Genetic Evaluation
 
 > How the NSIP system transforms raw performance data into Estimated Breeding Values using BLUP, and why the methodology matters for breeding decisions.

--- a/docs/explanation/MCP-SECURITY.md
+++ b/docs/explanation/MCP-SECURITY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # MCP Server Security Model
 
 > This document explains the design decisions, trade-offs, and threat model behind the NSIP MCP server's authentication and transport security. It is understanding-oriented -- read this to learn *why* the security layer works the way it does, not *how* to configure it.

--- a/docs/explanation/NSIP-DATA-MODEL.md
+++ b/docs/explanation/NSIP-DATA-MODEL.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # NSIP Data Model
 
 > How the NSIP Search API organizes sheep genetic evaluation data, from breed groups down to individual trait values.

--- a/docs/explanation/TELEMETRY.md
+++ b/docs/explanation/TELEMETRY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Telemetry and Distributed Tracing
 
 > Why the NSIP MCP server includes an optional telemetry system, how distributed tracing works, and the design decisions behind the implementation.

--- a/docs/how-to/BATCH-QUERY.md
+++ b/docs/how-to/BATCH-QUERY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Batch Query Multiple Animals
 
 > **Problem:** You need to retrieve data for many animals at once, either from a list of LPN IDs or by paginating through search results.

--- a/docs/how-to/COMPARE-ANIMALS.md
+++ b/docs/how-to/COMPARE-ANIMALS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Compare Animals
 
 > **Problem:** You need to compare EBV traits across multiple animals to inform breeding or selection decisions.

--- a/docs/how-to/CONFIGURE-CLIENT.md
+++ b/docs/how-to/CONFIGURE-CLIENT.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Configure the NSIP Client
 
 > **Problem:** You need to customize the HTTP client for timeouts, retries, or a different API endpoint.

--- a/docs/how-to/EXPORT-JSON.md
+++ b/docs/how-to/EXPORT-JSON.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Export Data as JSON
 
 > **Problem:** You need to export NSIP animal data in JSON format for further processing, reporting, or integration with other tools.

--- a/docs/how-to/FILTER-SEARCH-RESULTS.md
+++ b/docs/how-to/FILTER-SEARCH-RESULTS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Filter Search Results
 
 > **Problem:** You need to narrow down animals in the NSIP database by breed, gender, status, date range, flock, or trait values.

--- a/docs/how-to/OAUTH-AUTHENTICATION.md
+++ b/docs/how-to/OAUTH-AUTHENTICATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Authenticate with the NSIP MCP Server
 
 > **Problem:** You want to secure the NSIP MCP HTTP server so that only authorized users can access it, using OAuth 2.1 with GitHub as the identity provider or a GitHub Personal Access Token.

--- a/docs/how-to/SCRIPTING-INTEGRATION.md
+++ b/docs/how-to/SCRIPTING-INTEGRATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Integrate NSIP into Scripts and Pipelines
 
 > **Problem:** You want to automate NSIP data retrieval in shell scripts, CI pipelines, or data processing workflows.

--- a/docs/how-to/TELEMETRY.md
+++ b/docs/how-to/TELEMETRY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Enable and Use Telemetry
 
 > **Problem:** You want structured, machine-readable logs from the NSIP MCP server with W3C trace context so you can correlate log lines across a single request/response cycle.

--- a/docs/how-to/USE-MCP-TOOLS.md
+++ b/docs/how-to/USE-MCP-TOOLS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # How to Use the MCP Server Tools
 
 > **Problem:** You want to use the NSIP MCP server with an AI assistant (Claude Desktop, Claude Code, Cursor, etc.) to query sheep genetic data interactively.

--- a/docs/reference/CLI.md
+++ b/docs/reference/CLI.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # CLI Reference
 
 Complete reference for the `nsip` command-line interface.

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Configuration Reference
 
 Complete reference for configuring the `nsip` CLI and library.

--- a/docs/reference/ERROR-HANDLING.md
+++ b/docs/reference/ERROR-HANDLING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Error Handling Reference
 
 Complete reference for error handling in the `nsip` crate.

--- a/docs/reference/LIBRARY-API.md
+++ b/docs/reference/LIBRARY-API.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Library API Reference
 
 Complete reference for the `nsip` Rust library crate.

--- a/docs/reference/MCP-TOOLS.md
+++ b/docs/reference/MCP-TOOLS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # MCP Tools Reference
 
 Complete reference for the 13 tools exposed by the `nsip mcp` server.
@@ -8,7 +11,7 @@ For installation, configuration, resources, and prompts, see [MCP Server Referen
 
 ## Overview
 
-The MCP server exposes 13 tools over the Model Context Protocol (stdio transport, protocol version `2024-11-05`). All tools return JSON results as text content. Errors use standard MCP error codes.
+The MCP server exposes 13 tools over the Model Context Protocol (stdio transport, protocol version `2025-06-18`). All tools return JSON results as text content. Errors use standard MCP error codes.
 
 | Tool | Description |
 |------|-------------|

--- a/docs/tutorials/FIRST-API-QUERY.md
+++ b/docs/tutorials/FIRST-API-QUERY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Your First API Query
 
 > **Learning Goal:** By the end of this tutorial, you will know how to construct targeted searches using `SearchCriteria`, paginate through large result sets, sort by genetic traits, and combine multiple filters to find exactly the animals you need.

--- a/docs/tutorials/GETTING-STARTED.md
+++ b/docs/tutorials/GETTING-STARTED.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Getting Started with NSIP
 
 > **Learning Goal:** By the end of this tutorial, you will have a working Rust program that connects to the NSIP Search API, lists sheep breed groups, searches for animals, and retrieves detailed genetic data.

--- a/docs/tutorials/INTERPRETING-RESULTS.md
+++ b/docs/tutorials/INTERPRETING-RESULTS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Interpreting Results
 
 > **Learning Goal:** By the end of this tutorial, you will understand how to read the data returned by the NSIP API -- what EBV values mean, how to assess accuracy, how to read lineage data, and how to make sense of an animal's complete profile.

--- a/docs/tutorials/MCP-SERVER-SETUP.md
+++ b/docs/tutorials/MCP-SERVER-SETUP.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Setting Up the NSIP MCP Server
 
 > **Learning Goal:** By the end of this tutorial, you will have the NSIP MCP server running and connected to an AI assistant (Claude Desktop or Claude Code), ready to query sheep genetic data through natural language.


### PR DESCRIPTION
## Summary

Two documentation issues found during a nightly sweep of `main`:

### 1. Stale protocol version in `docs/reference/MCP-TOOLS.md`

The overview line in [`MCP-TOOLS.md`](docs/reference/MCP-TOOLS.md) referenced protocol version `2024-11-05`, which was superseded when the server upgraded to MCP `2025-06-18` in [#143](https://github.com/zircote/nsip/pull/143). All other docs (`MCP.md`, `USE-MCP-TOOLS.md`, `MCP-TOOL-SETS.md`, `MCP-SERVER-SETUP.md`) already had the correct version. PR #166 fixed many stale references but missed this one.

**Fix:** Update `2024-11-05` → `2025-06-18`.

### 2. Missing Diátaxis frontmatter on 26 of 29 docs

[ADR-0003](docs/adr/0003-adopt-diataxis-documentation-framework.md) and the 0.4.0-rc1 release adopted the Diátaxis framework, and the three most-recently-edited docs already carry `diataxis_type` frontmatter (`MCP-SERVER-CONFIGURATION.md`, `MATING-RECOMMENDATIONS.md`, `MCP-TOOL-SETS.md`). The remaining 26 docs across `reference/`, `explanation/`, `how-to/`, and `tutorials/` were missing it.

**Fix:** Add the appropriate `diataxis_type` frontmatter block to each file:

| Directory | `diataxis_type` value | Files updated |
|---|---|---|
| `docs/reference/` | `reference` | 5 |
| `docs/explanation/` | `explanation` | 8 |
| `docs/how-to/` | `how-to` | 9 |
| `docs/tutorials/` | `tutorial` | 4 |

## Files changed

- `docs/reference/MCP-TOOLS.md` — protocol version fix **+** frontmatter
- 25 other Markdown docs — frontmatter only (3-line prefix addition each)

## Testing

No code changes; documentation-only. Verified:
- All 29 docs in `reference/`, `explanation/`, `how-to/`, `tutorials/` now carry `diataxis_type` frontmatter.
- No stale `2024-11-05` protocol version references remain in `docs/`.




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22906841038) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22906841038, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22906841038 -->

<!-- gh-aw-workflow-id: update-docs -->