### PR TITLE
docs: add Diátaxis frontmatter to remaining 32 documentation files

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Deployment Guide
 
 This document provides comprehensive deployment instructions for the nsip project.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # NSIP MCP Server Reference
 
 The `nsip` binary ships a built-in [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that exposes the full NSIP Search API surface -- plus analytics-powered breeding intelligence -- to any MCP-compatible client (Claude Desktop, Claude Code, Cursor, etc.).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: explanation
+---
 # Documentation Index
 
 > All documentation for the nsip project organized using the [Diataxis framework](https://diataxis.fr/).

--- a/docs/distribution/ALTERNATIVE-REGISTRIES.md
+++ b/docs/distribution/ALTERNATIVE-REGISTRIES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Alternative Cargo Registries
 
 ## Overview

--- a/docs/distribution/DOCKER-REGISTRIES.md
+++ b/docs/distribution/DOCKER-REGISTRIES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Docker Multi-Registry Distribution
 
 ## Overview

--- a/docs/distribution/PACKAGE-MANAGERS.md
+++ b/docs/distribution/PACKAGE-MANAGERS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Package Manager Distribution
 
 ## Overview

--- a/docs/observability/METRICS-DASHBOARD.md
+++ b/docs/observability/METRICS-DASHBOARD.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Metrics & Observability Dashboard
 
 ## Overview

--- a/docs/runbooks/CI-TROUBLESHOOTING.md
+++ b/docs/runbooks/CI-TROUBLESHOOTING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # CI Troubleshooting
 
 Common CI failure patterns and fixes for nsip. Use this runbook when a workflow fails on a pull request or push to `main`.

--- a/docs/runbooks/DEPENDENCY-UPDATES.md
+++ b/docs/runbooks/DEPENDENCY-UPDATES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Dependency Updates
 
 Runbook for managing Cargo and GitHub Actions dependencies in nsip.

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Releasing
 
 End-to-end runbook for creating, monitoring, and rolling back releases of nsip.

--- a/docs/runbooks/SECURITY-RESPONSE.md
+++ b/docs/runbooks/SECURITY-RESPONSE.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Security Incident Response
 
 Runbook for handling security vulnerabilities in nsip. Based on the project's [Security Policy](../../SECURITY.md).

--- a/docs/security/SIGNED-RELEASES.md
+++ b/docs/security/SIGNED-RELEASES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Signed Releases & SLSA Provenance
 
 ## Overview

--- a/docs/template/CI-WORKFLOWS.md
+++ b/docs/template/CI-WORKFLOWS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # CI/CD Workflows Reference
 
 Comprehensive guide to every GitHub Actions workflow included in the

--- a/docs/template/CONFIGURATION.md
+++ b/docs/template/CONFIGURATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Template Configuration Guide
 
 > How to configure your new repository after creating it from the nsip.

--- a/docs/template/COPILOT-JUMPSTART.md
+++ b/docs/template/COPILOT-JUMPSTART.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Jumpstart Your Project with Copilot
 
 When you create a new repository from this template, GitHub offers an optional **"Jumpstart your project with Copilot"** prompt. Paste one of the prompts below into that field, and Copilot will open a pull request that scaffolds your project.

--- a/docs/template/CUSTOMIZATION.md
+++ b/docs/template/CUSTOMIZATION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: how-to
+---
 # Customization Guide
 
 This guide covers how to customize the `nsip` beyond the initial setup. For basic configuration (renaming the crate, updating metadata), see the main README.

--- a/docs/template/GETTING-STARTED.md
+++ b/docs/template/GETTING-STARTED.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: tutorial
+---
 # Getting Started
 
 > You just created a repository from **zircote/nsip**. This guide walks you through every step from creation to your first green CI run.

--- a/docs/template/GITHUB-TEMPLATE-FEATURES.md
+++ b/docs/template/GITHUB-TEMPLATE-FEATURES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # GitHub Template Repository Features
 
 > What copies when someone clicks **"Use this template"** — and what doesn't.

--- a/docs/testing/PROPERTY-BASED-TESTING.md
+++ b/docs/testing/PROPERTY-BASED-TESTING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Property-Based Testing Guide
 
 ## Overview

--- a/docs/ux/MAN-PAGES.md
+++ b/docs/ux/MAN-PAGES.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Man Pages Generation
 
 ## Overview

--- a/docs/ux/SHELL-COMPLETIONS.md
+++ b/docs/ux/SHELL-COMPLETIONS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Shell Completions
 
 ## Overview

--- a/docs/workflows/AGENTIC-WORKFLOWS.md
+++ b/docs/workflows/AGENTIC-WORKFLOWS.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Agentic Workflows
 
 ## Overview

--- a/docs/workflows/BENCHMARK-REGRESSION.md
+++ b/docs/workflows/BENCHMARK-REGRESSION.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Benchmark Regression Detection
 
 ## Overview

--- a/docs/workflows/CODE-QUALITY.md
+++ b/docs/workflows/CODE-QUALITY.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Code Quality Metrics
 
 ## Overview

--- a/docs/workflows/CONTAINER-SCAN.md
+++ b/docs/workflows/CONTAINER-SCAN.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Container Vulnerability Scanning with Trivy
 
 ## Overview

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Code Coverage Tracking
 
 ## Overview

--- a/docs/workflows/FUZZ-TESTING.md
+++ b/docs/workflows/FUZZ-TESTING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Fuzz Testing with cargo-fuzz
 
 ## Overview

--- a/docs/workflows/MUTATION-TESTING.md
+++ b/docs/workflows/MUTATION-TESTING.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Mutation Testing with cargo-mutants
 
 ## Overview

--- a/docs/workflows/SBOM.md
+++ b/docs/workflows/SBOM.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Software Bill of Materials (SBOM)
 
 ## Overview

--- a/docs/workflows/SECRETS-SCAN.md
+++ b/docs/workflows/SECRETS-SCAN.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Secrets Scanning with Gitleaks
 
 ## Overview

--- a/docs/workflows/SPELL-CHECK.md
+++ b/docs/workflows/SPELL-CHECK.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Spell Checking with typos
 
 ## Overview

--- a/docs/workflows/TEST-MATRIX.md
+++ b/docs/workflows/TEST-MATRIX.md
@@ -1,3 +1,6 @@
+---
+diataxis_type: reference
+---
 # Test Matrix - Multi-Platform Testing
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds `diataxis_type` YAML frontmatter to all 32 documentation files that were missing it, completing the Diátaxis framework adoption started in PR #169.

**Excluded (intentionally):**
- `docs/adr/` — ADR files use MADR structured frontmatter (`type: adr`, `status`, etc.)
- `docs/llm-guides/` — LLM agent configuration files, not user-facing docs

## Diátaxis Type Assignments

| Type | Files |
|------|-------|
| `how-to` | `docs/DEPLOYMENT.md`, `docs/runbooks/CI-TROUBLESHOOTING.md`, `docs/runbooks/DEPENDENCY-UPDATES.md`, `docs/runbooks/RELEASING.md`, `docs/runbooks/SECURITY-RESPONSE.md`, `docs/template/COPILOT-JUMPSTART.md`, `docs/template/CUSTOMIZATION.md` |
| `tutorial` | `docs/template/GETTING-STARTED.md` |
| `reference` | `docs/MCP.md`, `docs/distribution/*`, `docs/observability/METRICS-DASHBOARD.md`, `docs/security/SIGNED-RELEASES.md`, `docs/template/CI-WORKFLOWS.md`, `docs/template/CONFIGURATION.md`, `docs/template/GITHUB-TEMPLATE-FEATURES.md`, `docs/testing/PROPERTY-BASED-TESTING.md`, `docs/ux/MAN-PAGES.md`, `docs/ux/SHELL-COMPLETIONS.md`, `docs/workflows/*` |
| `explanation` | `docs/README.md` (documentation index/overview) |

## Changes

- 32 files modified
- Each file receives a 3-line YAML frontmatter block at the top: `---\ndiataxis_type: (type)\n---`
- No content changes — frontmatter only

## Rationale

The Diátaxis framework requires every documentation file to be classified by purpose. This classification enables:
- Better navigation and discoverability
- Consistent documentation tooling (e.g., docs-deploy workflow, search filtering)
- Clearer author intent for future contributors




> Generated by [Update Docs](https://github.com/zircote/nsip/actions/runs/22915508680) · [◷](https://github.com/search?q=repo%3Azircote%2Fnsip+%22gh-aw-workflow-id%3A+update-docs%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/eb7950f37d350af6fa09d19827c4883e72947221/workflows/update-docs.md), run
> ```
> gh aw add githubnext/agentics/workflows/update-docs.md@eb7950f37d350af6fa09d19827c4883e72947221
> ```

<!-- gh-aw-agentic-workflow: Update Docs, engine: copilot, id: 22915508680, workflow_id: update-docs, run: https://github.com/zircote/nsip/actions/runs/22915508680 -->

<!-- gh-aw-workflow-id: update-docs -->