### PR TITLE
chore(security): clear RUSTSEC advisories on rustls-webpki and rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1349,7 +1349,7 @@ dependencies = [
  "opentelemetry_sdk",
  "predicates",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest",
  "rmcp",
@@ -1402,7 +1402,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1533,7 +1533,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror",
 ]
 
@@ -1760,7 +1760,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1827,7 +1827,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1876,9 +1876,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2097,7 +2097,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2206,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,9 @@ redundant_pub_crate = "allow"
 # Allow multiple crate versions (can't control transitive deps)
 multiple_crate_versions = "allow"
 
+# Suggests Duration::from_mins (stable in 1.95) but our MSRV is 1.92
+duration_suboptimal_units = "allow"
+
 [features]
 default = []
 telemetry = [

--- a/crates/mcp/oauth/middleware.rs
+++ b/crates/mcp/oauth/middleware.rs
@@ -166,8 +166,7 @@ fn pat_claims(github_login: &str) -> NsipClaims {
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     NsipClaims {
         sub: github_login.to_owned(),


### PR DESCRIPTION
## Summary
- Bump rustls-webpki 0.103.9 → 0.103.13 (RUSTSEC-2026-0099 wildcard name-constraint, RUSTSEC-2026-0104 CRL panic)
- Bump rand 0.8.5 → 0.8.6, 0.9.2 → 0.9.4, 0.10.0 → 0.10.1 (RUSTSEC-2026-0097 unsoundness with custom logger)
- Replace `map(...).unwrap_or(0)` with `map_or(0, ...)` in `pat_claims` (clippy `map_unwrap_or`)
- Allow `clippy::duration_suboptimal_units` workspace-wide — the lint suggests `Duration::from_mins` (stable in 1.95) but our MSRV is 1.92

## Why
`cargo deny check advisories` and `cargo clippy -- -D warnings` are red on `main` since mid-March, blocking all 12 open dependabot PRs from passing the strict CI gate. This unblocks the queue.

## Test plan
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test` — 40 + 12 + 15 passing