### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-30
+
+### Documentation
+
+- Update CHANGELOG.md for v0.4.0
+- Fix NSIP_AUTH_ALLOWED_USERS gap and stale OTLP env var comment
+- Fix NSIP_AUTH_ISSUER default value and add optional OAuth vars to CONFIGURATION.md
+- Fix incorrect method names in LIBRARY-API.md analytics examples
+- Fix serve_stdio signature and add serve_http + with_tool_sets to LIBRARY-API.md
+- Fix stale version and MCP protocol references
+- Fix MCP-TOOLS protocol version and add Diátaxis frontmatter
+- Fix serve_stdio signature and MCP tool names in tutorials
+- Add Diátaxis frontmatter to remaining 32 documentation files
+- Fix just check description to include coverage step
+- Document agentics-maintenance workflow in AGENTIC-WORKFLOWS.md
+- Add workflow reference docs for CI, Release, Security Audit, and ADR workflows
+- Add workflow reference docs for 18 undocumented workflows
+
+### Fixed
+
+- **ci**: Fix dependabot automerge — use pull_request_target and add approval
+
+### Miscellaneous
+
+- **deps**: Bump tracing-subscriber from 0.3.22 to 0.3.23 (#179)
+- **deps**: Bump clap_complete from 4.5.66 to 4.6.0 (#180)
+- **deps**: Bump rmcp from 1.1.1 to 1.2.0 (#181)
+- **deps**: Bump the github-actions group across 1 directory with 6 updates (#190)
+- **deps**: Bump clap_mangen from 0.2.31 to 0.2.33 (#184)
+- **deps**: Bump clap from 4.5.60 to 4.6.0 (#182)
+- **deps**: Bump actions/download-artifact from 4.2.1 to 8.0.1 (#188)
+- **deps**: Bump tempfile from 3.26.0 to 3.27.0 (#185)
+- **deps**: Bump zircote/mcp-bundle (#187)
+- **security**: Bump rustls-webpki and rand to clear advisories (#214)
+- **deps**: Bump proptest (#207)
+- **deps**: Bump clap_complete from 4.6.0 to 4.6.3 (#212)
+- **deps**: Bump uuid from 1.22.0 to 1.23.1 (#210)
+- **deps**: Bump clap_mangen from 0.2.33 to 0.3.0 (#198)
+- **deps**: Bump opentelemetry-otlp from 0.31.0 to 0.31.1 (#191)
+- **deps**: Bump sha2 from 0.10.9 to 0.11.0 (#195)
+- **deps**: Bump assert_cmd from 2.1.2 to 2.2.1 (#209)
+- **deps**: Bump the github-actions group across 1 directory with 9 updates (#213)
+- **deps**: Bump zircote/mcp-bundle (#193)
+- **deps**: Bump tokio from 1.50.0 to 1.52.1 in the async-runtime group (#208)
+- **deps**: Bump rmcp from 1.2.0 to 1.5.0 (#211)
+
+### Ci
+
+- **gh-aw**: Recompile all workflows with gh-aw v0.56.2
+- **gh-aw**: Add agentics maintenance workflow
+- Replace inline mcpb packaging with zircote/mcp-bundle action
+- Use full commit SHA for mcp-bundle action pin
+- Use date+sha nightly bundle name (nsip-nightly-YYYYMMDD-SHA.mcpb)
+
 ## [0.4.0] - 2026-03-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps**: Bump tokio from 1.50.0 to 1.52.1 in the async-runtime group (#208)
 - **deps**: Bump rmcp from 1.2.0 to 1.5.0 (#211)
 
-### Ci
+### CI
 
 - **gh-aw**: Recompile all workflows with gh-aw v0.56.2
 - **gh-aw**: Add agentics maintenance workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"


### PR DESCRIPTION
## Summary
Release v0.5.0 — first cut since v0.4.0 (2026-03-09). Rolls up 21 commits: dependency bumps, security advisory fixes, CI improvements, and documentation.

## Highlights
- **Security**: Cleared RUSTSEC-2026-0097 (rand unsoundness), RUSTSEC-2026-0099 + RUSTSEC-2026-0104 (rustls-webpki name-constraint and CRL panic).
- **rmcp 1.2 → 1.5** with `tool_handler` API migration (`#[tool_handler(router = self.tool_router)]`) so `with_tool_sets` filtering keeps working.
- **Dependencies**: tokio 1.50→1.52, opentelemetry-otlp 0.31.0→0.31.1, uuid 1.22→1.23, sha2 0.10→0.11, clap_mangen 0.2→0.3, clap_complete 4.6.0→4.6.3, proptest 1.10→1.11, assert_cmd 2.1→2.2, tempfile 3.26→3.27, tracing-subscriber 0.3.22→0.3.23.
- **CI**: dependabot automerge fix (`pull_request_target` + approval), mcpb-bundle action refactor, date+SHA nightly artifact naming.
- **Docs**: Diátaxis frontmatter across 32 docs, NSIP_AUTH_* env-var gaps closed, library API signatures corrected, 18 previously-undocumented workflows documented.

## Verification
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test\` (40 + 12 + 15 passing)
- [x] \`cargo deny check\` (advisories, bans, licenses, sources all ok)
- [x] CHANGELOG.md regenerated via \`git-cliff --tag v0.5.0\`

## Release sequence
After this PR merges:
1. Tag \`v0.5.0\` on the merge commit → triggers \`.github/workflows/release.yml\`
2. Workflow builds platform binaries, MCPB bundle, Docker image, and publishes to crates.io

Full changelog: see \`CHANGELOG.md\`.