### PR TITLE
chore(deps): bump opentelemetry stack to consistent 0.32 / 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,9 +1379,9 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "jsonwebtoken",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "predicates",
  "proptest",
  "rand 0.10.1",
@@ -1502,20 +1502,6 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -1537,7 +1523,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "reqwest 0.13.3",
 ]
 
@@ -1548,10 +1534,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.32.0",
+ "opentelemetry_sdk",
  "prost",
  "reqwest 0.13.3",
  "thiserror",
@@ -1563,24 +1549,9 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.32.0",
- "opentelemetry_sdk 0.32.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror",
 ]
 
 [[package]]
@@ -1592,7 +1563,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -2916,12 +2887,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,10 +73,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # OpenTelemetry (optional, behind `telemetry` feature)
-opentelemetry = { version = "0.31", optional = true }
-opentelemetry_sdk = { version = "0.31", optional = true }
+opentelemetry = { version = "0.32", optional = true }
+opentelemetry_sdk = { version = "0.32", optional = true }
 opentelemetry-otlp = { version = "0.32", optional = true }
-tracing-opentelemetry = { version = "0.32", optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
 
 [dev-dependencies]
 # Testing

--- a/crates/mcp/telemetry.rs
+++ b/crates/mcp/telemetry.rs
@@ -9,10 +9,9 @@
 use std::fmt;
 use std::io;
 
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::trace::{TraceContextExt as _, TracerProvider as _};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::{Event, Subscriber};
-use tracing_opentelemetry::OtelData;
 use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
 use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::fmt::{FmtContext, FormattedFields};
@@ -139,10 +138,13 @@ where
     }
 }
 
-/// Walk the span scope from root to leaf and extract the first `OTel`
-/// `trace_id` / `span_id` into `map`.
+/// Extract the leaf span's `OTel` `trace_id` / `span_id` into `map`.
 ///
-/// Returns `true` if at least one of `trace_id` or `span_id` was inserted.
+/// Uses [`tracing_opentelemetry::get_otel_context`], the public SpanRef-friendly
+/// API introduced in tracing-opentelemetry 0.32.1 that replaces direct access
+/// to the now-private `OtelData` extension.
+///
+/// Returns `true` if a valid span context was found and inserted.
 fn extract_otel_context<S>(
     leaf: &tracing_subscriber::registry::SpanRef<'_, S>,
     map: &mut serde_json::Map<String, serde_json::Value>,
@@ -150,31 +152,27 @@ fn extract_otel_context<S>(
 where
     S: for<'lookup> LookupSpan<'lookup>,
 {
-    for span_ref in leaf.scope().from_root() {
-        let otel_data = {
-            let extensions = span_ref.extensions();
-            extensions
-                .get::<OtelData>()
-                .map(|d| (d.trace_id(), d.span_id()))
+    let mut inserted = false;
+    tracing::dispatcher::get_default(|dispatch| {
+        let Some(otel_ctx) = tracing_opentelemetry::get_otel_context(&leaf.id(), dispatch) else {
+            return;
         };
-        let Some((trace_id, span_id)) = otel_data else {
-            continue;
-        };
-        if let Some(tid) = trace_id {
-            map.insert(
-                "trace_id".to_owned(),
-                serde_json::Value::String(tid.to_string()),
-            );
+        let span = otel_ctx.span();
+        let span_context = span.span_context();
+        if !span_context.is_valid() {
+            return;
         }
-        if let Some(sid) = span_id {
-            map.insert(
-                "span_id".to_owned(),
-                serde_json::Value::String(sid.to_string()),
-            );
-        }
-        return true;
-    }
-    false
+        map.insert(
+            "trace_id".to_owned(),
+            serde_json::Value::String(span_context.trace_id().to_string()),
+        );
+        map.insert(
+            "span_id".to_owned(),
+            serde_json::Value::String(span_context.span_id().to_string()),
+        );
+        inserted = true;
+    });
+    inserted
 }
 
 /// Serialize a span reference to a JSON object with `name` and pre-formatted


### PR DESCRIPTION
## Summary

Consolidates the three open OpenTelemetry dependabot PRs (#228, #229, #236) into a single coherent bump. The OTEL Rust ecosystem requires all subcrates to share a minor version, and `tracing-opentelemetry` typically tracks one minor ahead — so the dependabot PRs could not have been merged individually.

| crate | before | after |
|-------|--------|-------|
| opentelemetry | 0.31 | 0.32 |
| opentelemetry_sdk | 0.31 | 0.32 |
| opentelemetry-otlp | 0.32 | 0.32 |
| tracing-opentelemetry | 0.32 | 0.33 |

## Migration note

`tracing-opentelemetry` 0.33 made `OtelData` private. `crates/mcp/telemetry.rs::extract_otel_context` is migrated to the public `tracing_opentelemetry::get_otel_context` API (added in 0.32.1), which works with `SpanRef` by looking up the OTel context through the current `tracing::Dispatch`. Behavior is preserved — trace_id/span_id still emit on every JSON log line.

## Replaces

- Closes #228
- Closes #229
- Closes #236

## Test plan

- [x] `cargo build --features telemetry`
- [x] `cargo test --all-features` (40 + 12 unit + 16 doc tests, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo deny check`
