### PR TITLE
ci: pin release builds to windows-2022

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   msi:
     name: Build Windows MSI Installer
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 40
     
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,8 +227,8 @@ jobs:
             target: aarch64-apple-darwin
             artifact_name: nsip
             asset_name: nsip-macos-arm64
-          # Windows x86_64
-          - os: windows-latest
+          # Windows x86_64 (pinned: deterministic release artifacts)
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             artifact_name: nsip.exe
             asset_name: nsip-windows-amd64.exe


### PR DESCRIPTION
## Summary
GitHub is remapping `windows-latest` to `windows-2025-vs2026` by 2026-06-15. Pin the release-critical workflows to `windows-2022` so release artifacts build deterministically on the exact image we've been testing on.

## Changes
- `release.yml` — Windows matrix target: `windows-latest` → `windows-2022`
- `package-windows.yml` — MSI installer job: `windows-latest` → `windows-2022`

CI, nightly, and test-matrix intentionally stay on `windows-latest` to keep exercising the upcoming image.
