### PR TITLE
ci: automate post-release back-merge + quiet docker attestation

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,0 +1,58 @@
+---
+name: Back-merge
+
+# After a release tag is pushed, main is ahead of develop by the release merge
+# commit. This workflow automatically opens (and merges) a PR back-merging main
+# into develop so the branches stay in sync without manual intervention.
+"on":
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  back-merge:
+    name: Back-merge main into develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Open and merge back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # Nothing to do if develop already contains main.
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "develop already contains main; nothing to back-merge."
+            exit 0
+          fi
+
+          TITLE="chore: back-merge main into develop (${TAG_NAME})"
+          BODY="Automated back-merge of the ${TAG_NAME} release commit from main into develop so the branches stay in sync. No code changes."
+
+          # Reuse an existing open main -> develop PR if present; otherwise create one.
+          PR_NUMBER="$(gh pr list --base develop --head main --state open --json number --jq '.[0].number' || true)"
+
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "Creating back-merge PR."
+            PR_NUMBER="$(gh pr create \
+              --title "${TITLE}" \
+              --body "${BODY}" \
+              --base develop \
+              --head main \
+              | grep -oE '[0-9]+$')"
+          else
+            echo "Back-merge PR #${PR_NUMBER} already exists."
+          fi
+
+          # Enable auto-merge so it lands once required checks pass.
+          gh pr merge "${PR_NUMBER}" --merge --auto

--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -40,18 +40,24 @@ jobs:
           BODY="Automated back-merge of the ${TAG_NAME} release commit from main into develop so the branches stay in sync. No code changes."
 
           # Reuse an existing open main -> develop PR if present; otherwise create one.
-          PR_NUMBER="$(gh pr list --base develop --head main --state open --json number --jq '.[0].number' || true)"
+          PR_NUMBER="$(gh pr list --base develop --head main --state open --json number --jq '.[0].number // empty' || true)"
 
           if [ -z "${PR_NUMBER}" ]; then
             echo "Creating back-merge PR."
-            PR_NUMBER="$(gh pr create \
+            gh pr create \
               --title "${TITLE}" \
               --body "${BODY}" \
               --base develop \
               --head main \
-              | grep -oE '[0-9]+$')"
+              >/dev/null
+            PR_NUMBER="$(gh pr list --base develop --head main --state open --json number --jq '.[0].number // empty')"
           else
             echo "Back-merge PR #${PR_NUMBER} already exists."
+          fi
+
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "Failed to determine back-merge PR number."
+            exit 1
           fi
 
           # Enable auto-merge so it lands once required checks pass.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,4 +69,7 @@ jobs:
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          # Keep provenance in GitHub's attestation store instead of pushing a
+          # sha256-<digest> referrer manifest to ghcr, which otherwise shows as
+          # an untagged "version" in the Packages UI. Verify via `gh attestation`.
+          push-to-registry: false

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -112,6 +112,7 @@ Pushing a `v*.*.*` tag triggers these workflows in parallel:
 | **Docker** | `docker.yml` | Builds multi-platform images (linux/amd64, linux/arm64), pushes to `ghcr.io/zircote/nsip` with version + `latest` tags |
 | **Publish** | `publish.yml` | Runs pre-publish checks and publishes to crates.io (if enabled and tag-triggered) |
 | **Signed Releases** | `signed-releases.yml` | Signs all release assets with Sigstore Cosign, generates SHA256/SHA512 checksums |
+| **Back-merge** | `back-merge.yml` | Automatically opens and auto-merges a `main -> develop` PR so the branches stay in sync after the release (no manual step) |
 
 ---
 


### PR DESCRIPTION
## Summary
Two release-automation improvements so the post-release sync is hands-off and the ghcr Packages UI stays clean.

## Changes
- **New back-merge.yml** — on a v*.*.* tag (or manual dispatch), automatically opens and auto-merges a main -> develop PR so develop absorbs the release merge commit without anyone prompting for it. No-op if develop already contains main.
- **docker.yml** — attest step push-to-registry=false: provenance stays in GitHub's attestation store instead of pushing a sha256-<digest> referrer manifest to ghcr (which showed as an untagged version in Packages). Verify via gh attestation.
- **RELEASING.md** — document the Back-merge workflow in the triggered-workflows table.