### PR TITLE
docs: correct release trigger accuracy in RELEASE.md

### DIFF
--- a/docs/workflows/RELEASE.md
+++ b/docs/workflows/RELEASE.md
@@ -106,15 +106,13 @@ Each binary is:
 #    merge it
 # 3. Tag the main merge commit and push the single tag
 git checkout main && git pull origin main
-git tag -s v1.2.3 -m "Release v1.2.3"
+git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 ```
 
 This triggers the release workflow automatically. See the
-[Releasing runbook](../runbooks/RELEASING.md) for the full promote-tag-push flow.
-
-See the [Releasing runbook](../runbooks/RELEASING.md) for the complete
-step-by-step release checklist.
+[Releasing runbook](../runbooks/RELEASING.md) for the full promote-tag-push flow
+and step-by-step release checklist.
 
 ## Downstream Workflows
 

--- a/docs/workflows/RELEASE.md
+++ b/docs/workflows/RELEASE.md
@@ -101,32 +101,33 @@ Each binary is:
 ## Triggering a Release
 
 ```bash
-# 1. Ensure CHANGELOG.md and version are up to date in Cargo.toml
-# 2. Commit all changes
-git add -A && git commit -m "chore: release v1.2.3"
-
-# 3. Create and push the version tag
+# 1. On develop: ensure CHANGELOG.md and the Cargo.toml version are up to date
+# 2. Promote develop -> main via a release PR (or the Release PR workflow) and
+#    merge it
+# 3. Tag the main merge commit and push the single tag
+git checkout main && git pull origin main
 git tag -s v1.2.3 -m "Release v1.2.3"
-git push origin main --tags
+git push origin v1.2.3
 ```
 
-This triggers the release workflow automatically.
+This triggers the release workflow automatically. See the
+[Releasing runbook](../runbooks/RELEASING.md) for the full promote-tag-push flow.
 
 See the [Releasing runbook](../runbooks/RELEASING.md) for the complete
 step-by-step release checklist.
 
 ## Downstream Workflows
 
-After the `create-release` job completes, the `release` event triggers
-several downstream workflows:
+Pushing the tag (and the release it creates) fans out to several workflows,
+each on its own trigger:
 
-| Workflow | Purpose |
-|----------|---------|
-| `docker.yml` | Builds and pushes Docker image to GHCR |
-| `signed-releases.yml` | Signs release binaries with Sigstore/Cosign |
-| `slsa-provenance.yml` | Generates SLSA provenance attestations |
-| `sbom.yml` | Attaches the SPDX SBOM to the release |
-| `changelog.yml` | Opens a PR to update `CHANGELOG.md` |
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `docker.yml` | tag push `v*.*.*` | Builds and pushes Docker image to GHCR |
+| `changelog.yml` | tag push `v*.*.*` | Opens a PR to update `CHANGELOG.md` |
+| `sbom.yml` | `release` published | Attaches the SPDX SBOM to the release |
+| `slsa-provenance.yml` | `release` published | Generates SLSA provenance attestations |
+| `signed-releases.yml` | `workflow_run` after Release | Signs release binaries with Sigstore/Cosign |
 
 > Package-manager workflows (Homebrew, Snap, Linux `.deb`/`.rpm`, Windows MSI)
 > are not currently included; re-add them and wire them to the `release` event


### PR DESCRIPTION
Carries two code-review findings from #256 that were applied to the working tree but not committed before merge.

- **`git push origin main --tags`** → replaced with the develop-promote-then-tag flow (`git checkout main && git pull`; `git push origin v1.2.3`), matching the RELEASING runbook and the develop-based branching model.
- **Downstream-workflows table** → now lists each workflow's real trigger (docker/changelog on tag push; sbom/slsa-provenance on `release` published; signed-releases on `workflow_run`) instead of claiming they all fire on the `release` event.