### PR TITLE
Release 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN cargo build --release && \
     rm -rf crates/
 
 # Copy actual source code and files referenced by include_str!
+# build.rs lives at the repo root and emits NSIP_ERROR_TYPE_URI_BASE via
+# cargo:rustc-env, which crates/lib.rs reads with env!(); it MUST be present
+# or the real build fails with "environment variable ... not defined".
 COPY README.md ./
+COPY build.rs ./
 COPY crates/ ./crates/
 
 # Invalidate cargo fingerprints so real source is compiled


### PR DESCRIPTION
## Release 0.6.1

Patch release on top of v0.6.0 to fix the Docker image build.

### Fix
- **fix(docker):** copy `build.rs` into the build stage. The image build re-compiled the real source without `build.rs` (repo root), so `env!("NSIP_ERROR_TYPE_URI_BASE")` had no value at compile time and the Docker build failed during the v0.6.0 release. Validated locally — the builder stage compiles and the image produces a working `nsip` binary.

### Note
v0.6.0 shipped successfully with signed binaries + GitHub release but no Docker image (this is the fix). No code/API changes since 0.6.0.

### Post-merge
Tag the merge commit `v0.6.1` and push — triggers release / publish / docker / sbom / slsa-provenance.
