### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"


### PR DESCRIPTION
Version bump 0.6.2 → 0.7.0 for the upcoming minor release.

- `Cargo.toml` package version → 0.7.0
- `Cargo.lock` nsip entry synced via `cargo check`

CHANGELOG.md is intentionally not touched here — `changelog.yml` regenerates it via git-cliff on the release tag and PRs it back into develop. After this merges, the release proceeds via the `Release PR` workflow (develop→main) and a `v0.7.0` tag on the main merge commit.