### PR TITLE
ci(docker): fix container attestation chain (ignore-unfixed + SBOM upload)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,9 +83,9 @@ jobs:
       attestations: write
       packages: write
       contents: read
-    # zircote/.github main @ 77a87549 (merged 2026-06-16)
+    # zircote/.github main @ 515a4c76 (no-release-upload SBOM fix, 2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/sign-and-attest.yml@740cb8efb57af0187f88e9b4f939355b871a5895
+      zircote/.github/.github/workflows/sign-and-attest.yml@515a4c765d9df26954f59d3fe4ab003f56651205
     with:
       image-name: ghcr.io/${{ github.repository }}
       image-digest: ${{ needs.build-and-push.outputs.image-digest }}
@@ -98,9 +98,9 @@ jobs:
       attestations: read
       packages: read
       contents: read
-    # zircote/.github main @ e8f0dbde (merged 2026-06-16)
+    # zircote/.github main @ 515a4c76 (2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/verify-attestation.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3
+      zircote/.github/.github/workflows/verify-attestation.yml@515a4c765d9df26954f59d3fe4ab003f56651205
     with:
       image-ref: >-
         ghcr.io/${{ github.repository }}@${{
@@ -123,14 +123,19 @@ jobs:
       security-events: write
       actions: read
       packages: read
-    # zircote/.github main @ 77a87549 (merged 2026-06-16)
+    # zircote/.github main @ 515a4c76 (adds ignore-unfixed input, 2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/reusable-trivy.yml@77a87549a65c6c978a0e87efe0168ed3517f7ca4
+      zircote/.github/.github/workflows/reusable-trivy.yml@515a4c765d9df26954f59d3fe4ab003f56651205
     with:
       image-ref: >-
         ghcr.io/${{ github.repository }}@${{
         needs.build-and-push.outputs.image-digest }}
       scan-iac: false
+      # Gate on FIXABLE vulnerabilities only. The distroless/Debian base
+      # carries unfixed glibc/openssl/gcc CVEs with no upstream patch (already
+      # at the latest deb12u* security versions); without this the image gate
+      # fails forever on findings that have no remediation.
+      ignore-unfixed: true
 
   attest-container-scan:
     name: Attest — Container scan
@@ -139,9 +144,9 @@ jobs:
       id-token: write
       attestations: write
       contents: read
-    # zircote/.github main @ 77a87549 (merged 2026-06-16)
+    # zircote/.github main @ 515a4c76 (2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/reusable-attest-scan.yml@740cb8efb57af0187f88e9b4f939355b871a5895
+      zircote/.github/.github/workflows/reusable-attest-scan.yml@515a4c765d9df26954f59d3fe4ab003f56651205
     with:
       subject-name: ghcr.io/${{ github.repository }}
       subject-digest: ${{ needs.build-and-push.outputs.image-digest }}


### PR DESCRIPTION
## Summary

Fixes the two defects in nsip's container attestation chain that surfaced on the **v0.7.0** release — the first time the chain ever executed (it's dormant in rust-template at `publish=false`).

## Defects fixed

1. **`Gate — Trivy (image)`** failed on 8 **unfixed** base-image CVEs (glibc/openssl/gcc, already at latest `deb12u*`). Now pins `reusable-trivy` to `zircote/.github@515a4c76` (which adds an `ignore-unfixed` input — zircote/.github#467) and passes `ignore-unfixed: true`, so the gate fails only on **fixable** vulnerabilities.
2. **`Sign and Attest Image`** failed: the reusable's SBOM step pushed the SBOM as a GitHub Release asset (sbom-action default) and 403'd under `contents: read`. Now pins `sign-and-attest` to `@515a4c76` (zircote/.github#468 disables that upload; the SBOM is attested as an OCI referrer, not a release asset).

Also repins `verify-attestation` + `reusable-attest-scan` to the same HEAD so the chain is a coherent, validated-together set.

## Validation

`workflow_dispatch` of `docker.yml` on this branch (run 27722655341) — **all jobs green**, including the previously-never-executed `Verify Image Attestations`, `Gate — Trivy (image)`, and `Attest — Container scan`:

- Build and Push Docker Image — success
- Sign and Attest Image — success
- Gate — Trivy (image) — success
- Attest — Container scan — success
- Verify Image Attestations — success

## Scope

v0.7.0's published image (signed + SLSA provenance) is accepted as-is; this fixes the chain for the next release. Follow-up worth considering: a static-musl/distroless-static base to remove glibc/openssl entirely (root-cause vs ignore-unfixed).
