### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"


### PR DESCRIPTION
Version bump 0.7.0 → 0.7.1 for the patch release that ships the fixed + native-build container chain (gh-attested image, native per-arch builds). Cargo.toml + Cargo.lock only; CHANGELOG is regenerated by changelog.yml on the tag. Release proceeds via the Release PR workflow (develop→main) + a v0.7.1 tag.