### PR TITLE
ci(docker): static musl binary on distroless/static (root-cause CVE fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-# Build stage
-FROM rust:1.92-slim AS builder
+# syntax=docker/dockerfile:1
+# Build stage — Alpine is musl-native, so `cargo build` targets the musl triple
+# and produces a fully STATIC binary (no glibc). That lets the runtime stage be
+# distroless/static (no glibc/openssl/libstdc++), eliminating the base-image
+# OS-package CVEs that a glibc image (distroless/cc) otherwise carries.
+ARG RUST_VERSION=1.92
+FROM rust:${RUST_VERSION}-alpine AS builder
+
+# musl-dev + build-base provide the C toolchain/assembler that ring (rustls'
+# crypto backend) compiles against; the musl target links it statically.
+RUN apk add --no-cache musl-dev build-base
 
 WORKDIR /app
 
 # Copy manifests
 COPY Cargo.toml Cargo.lock ./
 
-# Create dummy source to cache dependencies
+# Create dummy source to cache dependencies (build.rs is intentionally NOT
+# present yet — the dependency build needs no build script).
 RUN mkdir -p crates && \
     echo "fn main() {}" > crates/main.rs && \
     echo "" > crates/lib.rs
@@ -29,13 +39,16 @@ RUN rm -f target/release/deps/libnsip* \
          target/release/nsip && \
     cargo build --release
 
-# Runtime stage - use distroless for minimal attack surface
-FROM gcr.io/distroless/cc-debian12:latest
+# Runtime stage — distroless/static (no glibc/openssl) for a static musl binary.
+# TLS roots are bundled in the binary (reqwest rustls-tls -> webpki-roots), so
+# no system CA certs are required; the base still ships ca-certificates +
+# tzdata + a nonroot user for robustness.
+FROM gcr.io/distroless/static-debian12:nonroot
 
-# Copy binary from builder
+# Copy the statically-linked binary from builder
 COPY --from=builder /app/target/release/nsip /usr/local/bin/nsip
 
-# Set non-root user
+# Run as the distroless nonroot user (uid 65532)
 USER nonroot:nonroot
 
 # Health check


### PR DESCRIPTION
Eliminates the container's base-image CVEs at the source instead of suppressing them with `ignore-unfixed`.

**Before:** dynamic glibc binary (`rust:1.92-slim`) on `distroless/cc-debian12` → 8 unfixed glibc/openssl/gcc CVEs.
**After:** fully static musl binary (`rust:1.92-alpine`, musl-native) on `distroless/static-debian12` → no glibc/openssl/libstdc++.

TLS unaffected: reqwest `rustls-tls` bundles webpki-roots (no system CA store needed); ring compiles against musl-dev/build-base and links statically. Honors the `RUST_VERSION` build-arg.

**Validation:**
- Local (arm64): binary `statically linked`, runs on distroless/static, `trivy image --severity HIGH,CRITICAL` = **0 vulnerabilities** (was 8).
- CI dry-run (run 27727835856, both arches, 11min): build amd64+arm64 → merge → **Trivy gate clean** → sign → verify → container-scan attest, all green.

`ignore-unfixed` is left in docker.yml as harmless resilience (the static base now yields 0 findings regardless); can be dropped for a strict gate if preferred.