### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"


### PR DESCRIPTION
Patch release shipping the zero-CVE static-musl container image (#300). Cargo.toml + Cargo.lock only; CHANGELOG via git-cliff on tag.