### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nsip"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nsip"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 rust-version = "1.92"
 description = "NSIP Search API client for nsipsearch.nsip.org/api"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` package version 0.7.2 -> 0.7.3 (patch release)
- `Cargo.lock` regenerated via `cargo check`

## Test plan
- [x] `cargo fmt -- --check` passes
- [x] `cargo check` passes, `Cargo.lock`'s `nsip` entry updated to 0.7.3
