### PR TITLE
fix(ci): hardcode homebrew tap owner to zircote

### DIFF
--- a/.github/workflows/package-homebrew.yml
+++ b/.github/workflows/package-homebrew.yml
@@ -46,7 +46,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          repository: ${{ github.repository_owner }}/homebrew-tap
+          # Hardcoded: the tap lives under the personal zircote account and
+          # does not follow nsip's own repository owner (epicpast org).
+          repository: zircote/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 


### PR DESCRIPTION
## Summary
- `package-homebrew.yml` resolved the tap repo as `${{ github.repository_owner }}/homebrew-tap`, which broke when nsip moved from the `zircote` personal account to the `epicpast` org — the tap repo itself stayed under `zircote` and does not follow the org transfer
- v0.7.3's Homebrew Package run failed with a 404 fetching `epicpast/homebrew-tap` as a result (confirmed `zircote/homebrew-tap` exists and is the real tap)
- Hardcodes the checkout to `zircote/homebrew-tap`

## Test plan
- [x] Confirmed `gh repo view zircote/homebrew-tap` resolves correctly
- [x] No other `github.repository_owner`/`github.repository` reference in the file needs the same fix (the other two are for nsip's own repo, correctly dynamic)
