### PR TITLE
fix: remove no-op Approve PR step from dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -21,15 +21,6 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v2.2.0
 
-      - name: Approve PR
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -180,7 +180,7 @@ jobs:
       contents: read
     # zircote/.github main @ 515a4c76 (no-release-upload SBOM fix, 2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/sign-and-attest.yml@515a4c765d9df26954f59d3fe4ab003f56651205
+      zircote/.github/.github/workflows/sign-and-attest.yml@98cdea888a91e42874418e7173a265d6a546bc27
     with:
       image-name: ghcr.io/${{ github.repository }}
       image-digest: ${{ needs.merge.outputs.image-digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set up Docker Buildx
         # yamllint disable-line rule:line-length
-        uses: docker/setup-buildx-action@c887d9748da14dcb42b11cf8bcc773b301ea55b5  # v3.9.0
+        uses: docker/setup-buildx-action@5b9cf3909b54a280b6df6eee035755eb1f2fd611  # v3.9.0
 
       - name: Log in to Container Registry
         # yamllint disable-line rule:line-length
@@ -115,7 +115,7 @@ jobs:
 
       - name: Set up Docker Buildx
         # yamllint disable-line rule:line-length
-        uses: docker/setup-buildx-action@c887d9748da14dcb42b11cf8bcc773b301ea55b5  # v3.9.0
+        uses: docker/setup-buildx-action@5b9cf3909b54a280b6df6eee035755eb1f2fd611  # v3.9.0
 
       - name: Log in to Container Registry
         # yamllint disable-line rule:line-length

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,14 +58,14 @@ jobs:
       - name: Docker metadata (labels)
         id: meta
         # yamllint disable-line rule:line-length
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push by digest
         id: build
         # yamllint disable-line rule:line-length
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v6.10.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v6.10.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -128,7 +128,7 @@ jobs:
       - name: Docker metadata (tags)
         id: meta
         # yamllint disable-line rule:line-length
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -195,7 +195,7 @@ jobs:
       contents: read
     # zircote/.github main @ 515a4c76 (2026-06-17)
     uses: >-
-      zircote/.github/.github/workflows/verify-attestation.yml@515a4c765d9df26954f59d3fe4ab003f56651205
+      zircote/.github/.github/workflows/verify-attestation.yml@98cdea888a91e42874418e7173a265d6a546bc27
     with:
       image-ref: >-
         ghcr.io/${{ github.repository }}@${{

--- a/.github/workflows/package-homebrew.yml
+++ b/.github/workflows/package-homebrew.yml
@@ -46,7 +46,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          repository: ${{ github.repository_owner }}/homebrew-tap
+          # Hardcoded: the tap lives under the personal zircote account and
+          # does not follow nsip's own repository owner (epicpast org).
+          repository: zircote/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,6 @@ jobs:
       - name: Attest crate provenance
         if: startsWith(github.ref, 'refs/tags/v')
         # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: ${{ steps.crate.outputs.crate-path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Attest build provenance
         # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: dist/*
 
@@ -219,7 +219,7 @@ jobs:
 
       - name: Attest build provenance
         # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: dist/*
 
@@ -294,7 +294,7 @@ jobs:
 
       - name: Attest build provenance
         # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: dist/*
 
@@ -397,7 +397,7 @@ jobs:
 
       - name: Attest build provenance
         # yamllint disable-line rule:line-length
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: dist/${{ steps.pack.outputs.name }}
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install Rust toolchain
         # master
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           toolchain: stable
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install cargo-sbom
         # v2.67.18
-        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853
         with:
           tool: cargo-sbom
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,9 +3129,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",


### PR DESCRIPTION
GITHUB_TOKEN cannot approve pull requests, so this step has failed on every run since the workflow existed (see #335). Branch protection on `main` has no required review (`required_pull_request_reviews: null`), so the step was never gating anything — it only produced a false failing check on every dependabot PR.

Removes the step; `Enable auto-merge` (unaffected) still runs.

Fixes #335
